### PR TITLE
Fix services.yml update during install process

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -54,11 +54,11 @@ switch ($step) {
 
         file_put_contents(dirname(__DIR__).'/repository/Config/bootstrap.yml', $yaml->dump($bootstrap));
 
-        $servicesPath = realpath(__DIR__.'/../repository/Config/services.yml');
+        $servicesPath = dirname(__DIR__).'/repository/Config/services.yml';
         if (file_exists($servicesPath)) {
             $services = $yaml->parse($servicesPath);
         } else {
-            $services = ['parameters'];
+            $services = ['parameters' => []];
         }
 
         $services['parameters']['bbapp.cache.dir'] = realpath(__DIR__.'/../cache');


### PR DESCRIPTION
 * realpath() returns FALSE when file doesn't exist, trigerring an error on file_exists().
 * the initialized value of parameters is an empty array indexed by 'parameters'