### PR TITLE
[MISC] Remove support of PHP < 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "backbee/backbee-php": "~1.2.0",
+        "php": ">=5.6.0",
+        "backbee/backbee-php": "~1.3.0",
         "backbee/composer-handler": "~1.2.0",
         "backbee/demo-bundle": "~1.2.0",
-        "backbee/toolbar-bundle": "~1.2.0",
+        "backbee/toolbar-bundle": "~1.3.0",
         "badcow/lorem-ipsum": "~1.1.0",
         "eric-chau/bijective": "dev-master"
     },

--- a/public/BackBeeRequirements.php
+++ b/public/BackBeeRequirements.php
@@ -117,7 +117,7 @@ class Requirement
  */
 class BackBeeRequirements
 {
-    const REQUIRED_PHP_VERSION = '5.4.0';
+    const REQUIRED_PHP_VERSION = '5.6.0';
 
     /**
      * @return array


### PR DESCRIPTION
Resolved [#784](https://github.com/backbee/backbee-php/issues/784)
Due to an update of doctrine/common, php < 5.6 can no more be supported 